### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Fixes Missing GitHub Skills Activity

This PR addresses issue #6 by adding the missing GitHub Skills activity that was announced by the principal.

### ✅ Changes Made
- Added "GitHub Skills" activity to the activities database
- Description emphasizes the GitHub Certifications program and college application benefits
- Schedule: Mondays and Fridays, 3:00 PM - 4:30 PM
- Capacity: 25 students (higher than most activities to accommodate interest)
- Ready for student registrations

### 🚨 Urgency
This is time-sensitive as mentioned in the issue - registrations were supposed to close by the end of this week. Students are eager to join this program.

### 🧪 Testing
- [x] Activity appears in the activities list
- [x] Students can sign up for the activity
- [x] API endpoints work correctly
- [x] No breaking changes to existing functionality

Closes #6